### PR TITLE
Reorganize the code

### DIFF
--- a/p2pclient/config.py
+++ b/p2pclient/config.py
@@ -1,2 +1,2 @@
-control_maddr = "/unix/tmp/p2pd.sock"
-listen_maddr = "/unix/tmp/p2pclient.sock"
+control_maddr_str = "/unix/tmp/p2pd.sock"
+listen_maddr_str = "/unix/tmp/p2pclient.sock"

--- a/p2pclient/p2pclient.py
+++ b/p2pclient/p2pclient.py
@@ -35,7 +35,6 @@ from .pb import crypto_pb2 as crypto_pb
 class Client:
     control_maddr = None
     listen_maddr = None
-    listener = None
 
     handlers = None
 
@@ -69,6 +68,8 @@ class Client:
         try:
             handler = self.handlers[stream_info.proto]
         except KeyError as e:
+            # should never enter here... daemon should reject the stream for us.
+            writer.close()
             raise DispatchFailure(e)
         await handler(stream_info, reader, writer)
 

--- a/p2pclient/p2pclient.py
+++ b/p2pclient/p2pclient.py
@@ -5,6 +5,7 @@ import logging
 
 from multiaddr import (
     Multiaddr,
+    protocols,
 )
 
 from . import config
@@ -24,7 +25,6 @@ from .serialization import (
 )
 from .utils import (
     raise_if_failed,
-    trim_path_unix_prefix,
 )
 
 from .pb import p2pd_pb2 as p2pd_pb
@@ -44,19 +44,23 @@ class Client:
 
     def __init__(
             self,
-            _control_maddr=config.control_maddr,
-            _listen_maddr=config.control_maddr):
-        self.control_maddr = Multiaddr(_control_maddr)
-        self.listen_maddr = Multiaddr(_listen_maddr)
+            _control_maddr=None,
+            _listen_maddr=None):
+        if _control_maddr is None:
+            _control_maddr = Multiaddr(config.control_maddr_str)
+        if _listen_maddr is None:
+            _listen_maddr = Multiaddr(config.listen_maddr_str)
+        self.control_maddr = _control_maddr
+        self.listen_maddr = _listen_maddr
         self.handlers = {}
 
     @property
     def control_path(self):
-        return trim_path_unix_prefix(str(self.control_maddr))
+        return self.control_maddr.value_for_protocol(protocols.P_UNIX)
 
     @property
     def listen_path(self):
-        return trim_path_unix_prefix(str(self.listen_maddr))
+        return self.listen_maddr.value_for_protocol(protocols.P_UNIX)
 
     async def _dispatcher(self, reader, writer):
         pb_stream_info = p2pd_pb.StreamInfo()

--- a/p2pclient/p2pclient.py
+++ b/p2pclient/p2pclient.py
@@ -37,7 +37,6 @@ class Client:
     listen_maddr = None
     listener = None
 
-    mutex_handlers = None
     handlers = None
 
     logger = logging.getLogger('p2pclient.Client')

--- a/p2pclient/utils.py
+++ b/p2pclient/utils.py
@@ -10,11 +10,3 @@ def raise_if_failed(response):
                 response.error.msg,
             )
         )
-
-
-def trim_path_unix_prefix(path):
-    unix_prefix = "/unix"
-    # TODO: is it possible the path after "/unix" is a relative path?
-    if not path.startswith(unix_prefix):
-        raise ValueError(f"path {path} should start with the unix prefix {unix_prefix}")
-    return path[len(unix_prefix):]

--- a/p2pclient/utils.py
+++ b/p2pclient/utils.py
@@ -3,7 +3,6 @@ from .pb import p2pd_pb2 as p2pd_pb
 
 
 def raise_if_failed(response):
-    print("response = ", response)
     if response.type == p2pd_pb.Response.ERROR:
         raise ControlFailure(
             "connect failed. msg={}".format(

--- a/tests/test_p2pclient.py
+++ b/tests/test_p2pclient.py
@@ -1,0 +1,39 @@
+import pytest
+
+from multiaddr import (
+    Multiaddr,
+)
+
+from p2pclient import (
+    config,
+)
+from p2pclient.p2pclient import (
+    Client,
+)
+
+
+@pytest.mark.parametrize(
+    "control_maddr_str, listen_maddr_str",
+    (
+        ("/unix/123", "/ip4/127.0.0.1/tcp/7777"),
+        ("/ip4/127.0.0.1/tcp/6666", "/ip4/127.0.0.1/tcp/7777"),
+        ("/ip4/127.0.0.1/tcp/6666", "/unix/123"),
+        ("/unix/456", "/unix/123"),
+    ),
+)
+def test_client_ctor_control_listen_maddr(control_maddr_str, listen_maddr_str):
+    c = Client(Multiaddr(control_maddr_str), Multiaddr(listen_maddr_str))
+    assert c.control_maddr == Multiaddr(control_maddr_str)
+    assert c.listen_maddr == Multiaddr(listen_maddr_str)
+
+
+def test_client_ctor_default_control_listen_maddr():
+    c = Client()
+    assert c.control_maddr == Multiaddr(config.control_maddr_str)
+    assert c.listen_maddr == Multiaddr(config.listen_maddr_str)
+
+
+def test_client_listen_path():
+    c = Client(Multiaddr("/unix/456.sock"), Multiaddr("/unix/tmp/123.sock"))
+    assert c.control_path == "/456.sock"
+    assert c.listen_path == "/tmp/123.sock"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,18 @@
 import pytest
 
+from p2pclient.exceptions import ControlFailure
+from p2pclient.pb import p2pd_pb2 as p2pd_pb
+from p2pclient.utils import raise_if_failed
 
-# TODO: `raise_if_failed`
-def test_raise_if_failed():
-    pass
+
+def test_raise_if_failed_raises():
+    resp = p2pd_pb.Response()
+    resp.type = p2pd_pb.Response.ERROR
+    with pytest.raises(ControlFailure):
+        raise_if_failed(resp)
+
+
+def test_raise_if_failed_not_raises():
+    resp = p2pd_pb.Response()
+    resp.type = p2pd_pb.Response.OK
+    raise_if_failed(resp)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,38 +1,5 @@
 import pytest
 
-from p2pclient.utils import (
-    trim_path_unix_prefix,
-)
-
-
-@pytest.mark.parametrize(
-    "unix_path, expected",
-    (
-        ("/unix", ""),
-        ("/unix/", "/"),
-        ("/unix/path", "/path"),
-        ("/unix/path/2", "/path/2"),
-    ),
-)
-def test_trim_path_unix_prefix_success(unix_path, expected):
-    assert trim_path_unix_prefix(unix_path) == expected
-
-
-@pytest.mark.parametrize(
-    "unix_path",
-    (
-        "",
-        "/123",
-        "/123/456",
-        "//unix",
-        " /unix",
-        "unix",
-    )
-)
-def test_trim_path_unix_prefix_failure(unix_path):
-    with pytest.raises(ValueError):
-        trim_path_unix_prefix(unix_path)
-
 
 # TODO: `raise_if_failed`
 def test_raise_if_failed():


### PR DESCRIPTION
- Use `Multiaddr.value_for_protocol(protocols.P_UNIX)` to get the value of UNIX protocol
- Add non-integration tests for `Client`
- Add tests for `raise_if_failed`
- Add tests for `stream_handler`, to verify the behavior when registering the same protocol twice.