### PR TITLE
Confirmed behavior of Connmgr

### DIFF
--- a/p2pclient/p2pclient.py
+++ b/p2pclient/p2pclient.py
@@ -74,7 +74,6 @@ def parse_conn_protocol(maddr: Multiaddr) -> int:
     return tuple(proto_cand)[0]
 
 
-# TODO: add support for socket stream
 class Client:
     control_maddr: Multiaddr
     listen_maddr: Multiaddr


### PR DESCRIPTION
Fixes https://github.com/mhchia/py-libp2p-daemon-bindings/issues/8
- Add `test_client_trim_automatically_by_connmgr` and `test_client_trim`
- Add option `enable_connmgr`, to enable the connmgr only in the related
tests, to avoid affecting the other unrelated tests
- Increase `NUM_P2PDS` to 4, to ease testing of `trim`