### PR TITLE
Add checks when cleaning up p2pd_pairs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
+      dist: xenial
     - python: 3.6
       env: TOXENV=lint
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: python
+matrix:
+  include:
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.6
+      env: TOXENV=lint
 
 sudo: true
-
-python:
-  - "3.6"
 
 env:
   - GOPACKAGE=go1.11.5.linux-amd64.tar.gz LIBP2P_DAEMON_REPO=github.com/libp2p/go-libp2p-daemon

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ matrix:
 sudo: true
 
 env:
-  - GOPACKAGE=go1.11.5.linux-amd64.tar.gz LIBP2P_DAEMON_REPO=github.com/libp2p/go-libp2p-daemon
+  global:
+    - GOPACKAGE=go1.11.5.linux-amd64.tar.gz LIBP2P_DAEMON_REPO=github.com/libp2p/go-libp2p-daemon
 
 before_install:
   # install go

--- a/tests/test_p2pclient_integration.py
+++ b/tests/test_p2pclient_integration.py
@@ -171,8 +171,10 @@ async def p2pds(request, enable_connmgr):
 
     # clean up
     for p2pd_pair in p2pd_pairs:
-        p2pd_pair.daemon.close()
-        await p2pd_pair.client.close()
+        if not p2pd_pair.daemon.is_closed:
+            p2pd_pair.daemon.close()
+        if p2pd_pair.client.listener is not None:
+            await p2pd_pair.client.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_p2pclient_integration.py
+++ b/tests/test_p2pclient_integration.py
@@ -198,10 +198,8 @@ async def test_client_close(p2pds):
     await c0.close()
     assert c0.listener is None
     # test case: ensure there is no sockets after closing
-    assert (
-        listener.sockets is None or  # for versions before python 3.7
-        len(listener.socket) == 0  # for versions 3.7+
-    )
+    # for versions before python 3.7 and 3.7+, respectively
+    assert listener.sockets is None or len(listener.socket) == 0
     # test case: it's fine to listen again, after closing
     await c0.listen()
 

--- a/tests/test_p2pclient_integration.py
+++ b/tests/test_p2pclient_integration.py
@@ -198,7 +198,10 @@ async def test_client_close(p2pds):
     await c0.close()
     assert c0.listener is None
     # test case: ensure there is no sockets after closing
-    assert listener.sockets is None
+    assert (
+        listener.sockets is None or  # for versions before python 3.7
+        len(listener.socket) == 0  # for versions 3.7+
+    )
     # test case: it's fine to listen again, after closing
     await c0.listen()
 

--- a/tests/test_p2pclient_integration.py
+++ b/tests/test_p2pclient_integration.py
@@ -199,7 +199,7 @@ async def test_client_close(p2pds):
     assert c0.listener is None
     # test case: ensure there is no sockets after closing
     # for versions before python 3.7 and 3.7+, respectively
-    assert listener.sockets is None or len(listener.socket) == 0
+    assert listener.sockets is None or len(listener.sockets) == 0
     # test case: it's fine to listen again, after closing
     await c0.listen()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint, py36
+envlist = lint, py36, py37
 
 [testenv]  # default
 setenv =


### PR DESCRIPTION
Close `Daemon` and `Client` only if they are not closed, to prevent from errors. If errors occur and p2pds are not closed correctly, following tests will be affected, which makes debugging harder