### PR TITLE
Change to anyio

### DIFF
--- a/p2pclient/connmgr.py
+++ b/p2pclient/connmgr.py
@@ -21,11 +21,11 @@ class ConnectionManagerClient:
             weight=weight,
         )
         req = p2pd_pb.Request(type=p2pd_pb.Request.CONNMANAGER, connManager=connmgr_req)
-        reader, writer = await self.daemon_connector.open_connection()
-        await write_pbmsg(writer, req)
+        stream = await self.daemon_connector.open_connection()
+        await write_pbmsg(stream, req)
         resp = p2pd_pb.Response()  # type: ignore
-        await read_pbmsg_safe(reader, resp)
-        writer.close()
+        await read_pbmsg_safe(stream, resp)
+        await stream.close()
         raise_if_failed(resp)
 
     async def untag_peer(self, peer_id: ID, tag: str) -> None:
@@ -35,11 +35,11 @@ class ConnectionManagerClient:
             type=p2pd_pb.ConnManagerRequest.UNTAG_PEER, peer=peer_id.to_bytes(), tag=tag
         )
         req = p2pd_pb.Request(type=p2pd_pb.Request.CONNMANAGER, connManager=connmgr_req)
-        reader, writer = await self.daemon_connector.open_connection()
-        await write_pbmsg(writer, req)
+        stream = await self.daemon_connector.open_connection()
+        await write_pbmsg(stream, req)
         resp = p2pd_pb.Response()  # type: ignore
-        await read_pbmsg_safe(reader, resp)
-        writer.close()
+        await read_pbmsg_safe(stream, resp)
+        await stream.close()
         raise_if_failed(resp)
 
     async def trim(self) -> None:
@@ -47,9 +47,9 @@ class ConnectionManagerClient:
         """
         connmgr_req = p2pd_pb.ConnManagerRequest(type=p2pd_pb.ConnManagerRequest.TRIM)
         req = p2pd_pb.Request(type=p2pd_pb.Request.CONNMANAGER, connManager=connmgr_req)
-        reader, writer = await self.daemon_connector.open_connection()
-        await write_pbmsg(writer, req)
+        stream = await self.daemon_connector.open_connection()
+        await write_pbmsg(stream, req)
         resp = p2pd_pb.Response()  # type: ignore
-        await read_pbmsg_safe(reader, resp)
-        writer.close()
+        await read_pbmsg_safe(stream, resp)
+        await stream.close()
         raise_if_failed(resp)

--- a/p2pclient/control.py
+++ b/p2pclient/control.py
@@ -86,7 +86,7 @@ class ControlClient:
         async for client in server.accept_connections():
             await self.task_group.spawn(self._dispatcher, client)
 
-    async def _dispatcher(self, stream: anyio.abc.Stream) -> None:
+    async def _dispatcher(self, stream: anyio.abc.SocketStream) -> None:
         pb_stream_info = p2pd_pb.StreamInfo()  # type: ignore
         await read_pbmsg_safe(stream, pb_stream_info)
         stream_info = StreamInfo.from_pb(pb_stream_info)

--- a/p2pclient/control.py
+++ b/p2pclient/control.py
@@ -1,7 +1,8 @@
-import asyncio
 import logging
-from typing import Awaitable, Callable, Dict, Iterable, Sequence, Tuple
+from typing import AsyncIterator, Awaitable, Callable, Dict, Iterable, Sequence, Tuple
 
+import anyio
+from async_generator import asynccontextmanager
 from libp2p.peer.id import ID
 from multiaddr import Multiaddr, protocols
 
@@ -11,9 +12,7 @@ from .exceptions import ControlFailure, DispatchFailure
 from .pb import p2pd_pb2 as p2pd_pb
 from .utils import raise_if_failed, read_pbmsg_safe, write_pbmsg
 
-StreamHandler = Callable[
-    [StreamInfo, asyncio.StreamReader, asyncio.StreamWriter], Awaitable[None]
-]
+StreamHandler = Callable[[StreamInfo, anyio.abc.SocketStream], Awaitable[None]]
 
 
 _supported_conn_protocols = (
@@ -46,20 +45,18 @@ class DaemonConnector:
             control_maddr = Multiaddr(config.control_maddr_str)
         self.control_maddr = control_maddr
 
-    async def open_connection(
-        self
-    ) -> Tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    async def open_connection(self) -> anyio.abc.SocketStream:
         proto_code = parse_conn_protocol(self.control_maddr)
         if proto_code == protocols.P_UNIX:
             control_path = self.control_maddr.value_for_protocol(protocols.P_UNIX)
             self.logger.debug(
                 "DaemonConnector %s opens connection to %s", self, self.control_maddr
             )
-            return await asyncio.open_unix_connection(control_path)
+            return await anyio.connect_unix(control_path)
         elif proto_code == protocols.P_IP4:
             host = self.control_maddr.value_for_protocol(protocols.P_IP4)
             port = int(self.control_maddr.value_for_protocol(protocols.P_TCP))
-            return await asyncio.open_connection(host=host, port=port)
+            return await anyio.connect_tcp(address=host, port=port)
         else:
             raise ValueError(
                 f"protocol not supported: protocol={protocols.protocol_with_code(proto_code)}"
@@ -70,7 +67,8 @@ class ControlClient:
     listen_maddr: Multiaddr
     daemon_connector: DaemonConnector
     handlers: Dict[str, StreamHandler]
-    listener: asyncio.AbstractServer = None
+    listener: anyio.abc.SocketStreamServer = None
+    task_group: anyio.abc.TaskGroup = None
     logger = logging.getLogger("p2pclient.ControlClient")
 
     def __init__(
@@ -82,58 +80,65 @@ class ControlClient:
         self.daemon_connector = daemon_connector
         self.handlers = {}
 
-    async def _dispatcher(
-        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    async def _accept_new_connections(
+        self, server: anyio.abc.SocketStreamServer
     ) -> None:
+        async for client in server.accept_connections():
+            await self.task_group.spawn(self._dispatcher, client)
+
+    async def _dispatcher(self, stream: anyio.abc.Stream) -> None:
         pb_stream_info = p2pd_pb.StreamInfo()  # type: ignore
-        await read_pbmsg_safe(reader, pb_stream_info)
+        await read_pbmsg_safe(stream, pb_stream_info)
         stream_info = StreamInfo.from_pb(pb_stream_info)
         self.logger.info("New incoming stream: %s", stream_info)
         try:
             handler = self.handlers[stream_info.proto]
         except KeyError as e:
             # should never enter here... daemon should reject the stream for us.
-            writer.close()
+            await stream.close()
             raise DispatchFailure(e)
-        await handler(stream_info, reader, writer)
+        await handler(stream_info, stream)
 
-    async def listen(self) -> None:
+    @asynccontextmanager
+    async def listen(self) -> AsyncIterator["ControlClient"]:
         if self.listener is not None:
             raise ControlFailure("Listener is already listening")
         proto_code = parse_conn_protocol(self.listen_maddr)
         if proto_code == protocols.P_UNIX:
             listen_path = self.listen_maddr.value_for_protocol(protocols.P_UNIX)
-            self.listener = await asyncio.start_unix_server(
-                self._dispatcher, listen_path
-            )
+            self.listener = await anyio.create_unix_server(listen_path)
         elif proto_code == protocols.P_IP4:
             host = self.listen_maddr.value_for_protocol(protocols.P_IP4)
             port = int(self.listen_maddr.value_for_protocol(protocols.P_TCP))
-            self.listener = await asyncio.start_server(
-                self._dispatcher, host=host, port=port
-            )
+            self.listener = await anyio.create_tcp_server(port=port, interface=host)
         else:
             raise ValueError(
                 f"protocol not supported: protocol={protocols.protocol_with_code(proto_code)}"
             )
-        self.logger.info(
-            "DaemonConnector %s starts listening to %s", self, self.listen_maddr
-        )
-
-    async def close(self) -> None:
-        self.listener.close()
-        await self.listener.wait_closed()
-        self.listener = None
+        async with anyio.create_task_group() as task_group:
+            self.task_group = task_group
+            async with self.listener:
+                await task_group.spawn(self._accept_new_connections, self.listener)
+                self.logger.info(
+                    "DaemonConnector %s starts listening to %s", self, self.listen_maddr
+                )
+                yield self
+            self.listener = None
+            await self.close()
+            self.task_group = None
         self.logger.info("DaemonConnector %s closed", self)
 
+    async def close(self) -> None:
+        await self.task_group.cancel_scope.cancel()
+
     async def identify(self) -> Tuple[ID, Tuple[Multiaddr, ...]]:
-        reader, writer = await self.daemon_connector.open_connection()
+        stream = await self.daemon_connector.open_connection()
         req = p2pd_pb.Request(type=p2pd_pb.Request.IDENTIFY)
-        await write_pbmsg(writer, req)
+        await write_pbmsg(stream, req)
 
         resp = p2pd_pb.Response()  # type: ignore
-        await read_pbmsg_safe(reader, resp)
-        writer.close()
+        await read_pbmsg_safe(stream, resp)
+        await stream.close()
         raise_if_failed(resp)
         peer_id_bytes = resp.identify.id
         maddrs_bytes = resp.identify.addrs
@@ -144,27 +149,27 @@ class ControlClient:
         return peer_id, maddrs
 
     async def connect(self, peer_id: ID, maddrs: Iterable[Multiaddr]) -> None:
-        reader, writer = await self.daemon_connector.open_connection()
+        stream = await self.daemon_connector.open_connection()
 
         maddrs_bytes = [i.to_bytes() for i in maddrs]
         connect_req = p2pd_pb.ConnectRequest(
             peer=peer_id.to_bytes(), addrs=maddrs_bytes
         )
         req = p2pd_pb.Request(type=p2pd_pb.Request.CONNECT, connect=connect_req)
-        await write_pbmsg(writer, req)
+        await write_pbmsg(stream, req)
 
         resp = p2pd_pb.Response()  # type: ignore
-        await read_pbmsg_safe(reader, resp)
-        writer.close()
+        await read_pbmsg_safe(stream, resp)
+        await stream.close()
         raise_if_failed(resp)
 
     async def list_peers(self) -> Tuple[PeerInfo, ...]:
         req = p2pd_pb.Request(type=p2pd_pb.Request.LIST_PEERS)
-        reader, writer = await self.daemon_connector.open_connection()
-        await write_pbmsg(writer, req)
+        stream = await self.daemon_connector.open_connection()
+        await write_pbmsg(stream, req)
         resp = p2pd_pb.Response()  # type: ignore
-        await read_pbmsg_safe(reader, resp)
-        writer.close()
+        await read_pbmsg_safe(stream, resp)
+        await stream.close()
         raise_if_failed(resp)
 
         peers = tuple(PeerInfo.from_pb(pinfo) for pinfo in resp.peers)
@@ -175,17 +180,17 @@ class ControlClient:
         req = p2pd_pb.Request(
             type=p2pd_pb.Request.DISCONNECT, disconnect=disconnect_req
         )
-        reader, writer = await self.daemon_connector.open_connection()
-        await write_pbmsg(writer, req)
+        stream = await self.daemon_connector.open_connection()
+        await write_pbmsg(stream, req)
         resp = p2pd_pb.Response()  # type: ignore
-        await read_pbmsg_safe(reader, resp)
-        writer.close()
+        await read_pbmsg_safe(stream, resp)
+        await stream.close()
         raise_if_failed(resp)
 
     async def stream_open(
         self, peer_id: ID, protocols: Sequence[str]
-    ) -> Tuple[StreamInfo, asyncio.StreamReader, asyncio.StreamWriter]:
-        reader, writer = await self.daemon_connector.open_connection()
+    ) -> Tuple[StreamInfo, anyio.abc.SocketStream]:
+        stream = await self.daemon_connector.open_connection()
 
         stream_open_req = p2pd_pb.StreamOpenRequest(
             peer=peer_id.to_bytes(), proto=list(protocols)
@@ -193,19 +198,19 @@ class ControlClient:
         req = p2pd_pb.Request(
             type=p2pd_pb.Request.STREAM_OPEN, streamOpen=stream_open_req
         )
-        await write_pbmsg(writer, req)
+        await write_pbmsg(stream, req)
 
         resp = p2pd_pb.Response()  # type: ignore
-        await read_pbmsg_safe(reader, resp)
+        await read_pbmsg_safe(stream, resp)
         raise_if_failed(resp)
 
         pb_stream_info = resp.streamInfo
         stream_info = StreamInfo.from_pb(pb_stream_info)
 
-        return stream_info, reader, writer
+        return stream_info, stream
 
     async def stream_handler(self, proto: str, handler_cb: StreamHandler) -> None:
-        reader, writer = await self.daemon_connector.open_connection()
+        stream = await self.daemon_connector.open_connection()
 
         listen_path_maddr_bytes = self.listen_maddr.to_bytes()
         stream_handler_req = p2pd_pb.StreamHandlerRequest(
@@ -214,11 +219,11 @@ class ControlClient:
         req = p2pd_pb.Request(
             type=p2pd_pb.Request.STREAM_HANDLER, streamHandler=stream_handler_req
         )
-        await write_pbmsg(writer, req)
+        await write_pbmsg(stream, req)
 
         resp = p2pd_pb.Response()  # type: ignore
-        await read_pbmsg_safe(reader, resp)
-        writer.close()
+        await read_pbmsg_safe(stream, resp)
+        await stream.close()
         raise_if_failed(resp)
 
         # if success, add the handler to the dict

--- a/p2pclient/dht.py
+++ b/p2pclient/dht.py
@@ -1,6 +1,6 @@
-import asyncio
 from typing import AsyncGenerator, Tuple
 
+import anyio
 from libp2p.crypto.pb import crypto_pb2 as crypto_pb
 from libp2p.peer.id import ID
 
@@ -19,11 +19,11 @@ class DHTClient:
 
     @staticmethod
     async def _read_dht_stream(
-        reader: asyncio.StreamReader
+        stream: anyio.abc.SocketStream
     ) -> AsyncGenerator[p2pd_pb.DHTResponse, None]:
         while True:
             dht_resp = p2pd_pb.DHTResponse()  # type: ignore
-            await read_pbmsg_safe(reader, dht_resp)
+            await read_pbmsg_safe(stream, dht_resp)
             if dht_resp.type == dht_resp.END:
                 break
             yield dht_resp
@@ -31,11 +31,11 @@ class DHTClient:
     async def _do_dht(
         self, dht_req: p2pd_pb.DHTRequest
     ) -> Tuple[p2pd_pb.DHTResponse, ...]:
-        reader, writer = await self.daemon_connector.open_connection()
+        stream = await self.daemon_connector.open_connection()
         req = p2pd_pb.Request(type=p2pd_pb.Request.DHT, dht=dht_req)
-        await write_pbmsg(writer, req)
+        await write_pbmsg(stream, req)
         resp = p2pd_pb.Response()  # type: ignore
-        await read_pbmsg_safe(reader, resp)
+        await read_pbmsg_safe(stream, resp)
         raise_if_failed(resp)
 
         try:
@@ -49,8 +49,8 @@ class DHTClient:
         if dht_resp.type != dht_resp.BEGIN:
             raise ControlFailure(f"Type should be BEGIN instead of {dht_resp.type}")
         # BEGIN/END stream
-        resps = tuple([i async for i in self._read_dht_stream(reader)])
-        writer.close()
+        resps = tuple([i async for i in self._read_dht_stream(stream)])
+        await stream.close()
         return resps
 
     async def find_peer(self, peer_id: ID) -> PeerInfo:
@@ -174,11 +174,11 @@ class DHTClient:
             type=p2pd_pb.DHTRequest.PUT_VALUE, key=key, value=value
         )
         req = p2pd_pb.Request(type=p2pd_pb.Request.DHT, dht=dht_req)
-        reader, writer = await self.daemon_connector.open_connection()
-        await write_pbmsg(writer, req)
+        stream = await self.daemon_connector.open_connection()
+        await write_pbmsg(stream, req)
         resp = p2pd_pb.Response()  # type: ignore
-        await read_pbmsg_safe(reader, resp)
-        writer.close()
+        await read_pbmsg_safe(stream, resp)
+        await stream.close()
         raise_if_failed(resp)
 
     async def provide(self, cid: bytes) -> None:
@@ -186,9 +186,9 @@ class DHTClient:
         """
         dht_req = p2pd_pb.DHTRequest(type=p2pd_pb.DHTRequest.PROVIDE, cid=cid)
         req = p2pd_pb.Request(type=p2pd_pb.Request.DHT, dht=dht_req)
-        reader, writer = await self.daemon_connector.open_connection()
-        await write_pbmsg(writer, req)
+        stream = await self.daemon_connector.open_connection()
+        await write_pbmsg(stream, req)
         resp = p2pd_pb.Response()  # type: ignore
-        await read_pbmsg_safe(reader, resp)
-        writer.close()
+        await read_pbmsg_safe(stream, resp)
+        await stream.close()
         raise_if_failed(resp)

--- a/p2pclient/dht.py
+++ b/p2pclient/dht.py
@@ -19,7 +19,7 @@ class DHTClient:
 
     @staticmethod
     async def _read_dht_stream(
-        stream: anyio.abc.SocketStream
+        stream: anyio.abc.SocketStream,
     ) -> AsyncGenerator[p2pd_pb.DHTResponse, None]:
         while True:
             dht_resp = p2pd_pb.DHTResponse()  # type: ignore

--- a/p2pclient/p2pclient.py
+++ b/p2pclient/p2pclient.py
@@ -109,5 +109,5 @@ class Client:
     async def pubsub_publish(self, topic: str, data: bytes) -> None:
         return await self.pubsub.publish(topic=topic, data=data)
 
-    async def pubsub_subscribe(self, topic: str) -> Tuple[anyio.abc.SocketStream]:
+    async def pubsub_subscribe(self, topic: str) -> anyio.abc.SocketStream:
         return await self.pubsub.subscribe(topic=topic)

--- a/p2pclient/p2pclient.py
+++ b/p2pclient/p2pclient.py
@@ -1,6 +1,7 @@
-import asyncio
-from typing import Iterable, Sequence, Tuple
+from typing import AsyncIterator, Iterable, Sequence, Tuple
 
+import anyio
+from async_generator import asynccontextmanager
 from libp2p.crypto.pb import crypto_pb2 as crypto_pb
 from libp2p.peer.id import ID
 from multiaddr import Multiaddr
@@ -29,8 +30,10 @@ class Client:
         self.dht = DHTClient(daemon_connector=daemon_connector)
         self.pubsub = PubSubClient(daemon_connector=daemon_connector)
 
-    async def listen(self) -> None:
-        await self.control.listen()
+    @asynccontextmanager
+    async def listen(self) -> AsyncIterator["Client"]:
+        async with self.control.listen():
+            yield self
 
     async def close(self) -> None:
         await self.control.close()
@@ -49,7 +52,7 @@ class Client:
 
     async def stream_open(
         self, peer_id: ID, protocols: Sequence[str]
-    ) -> Tuple[StreamInfo, asyncio.StreamReader, asyncio.StreamWriter]:
+    ) -> Tuple[StreamInfo, anyio.abc.SocketStream]:
         return await self.control.stream_open(peer_id=peer_id, protocols=protocols)
 
     async def stream_handler(self, proto: str, handler_cb: StreamHandler) -> None:
@@ -106,7 +109,5 @@ class Client:
     async def pubsub_publish(self, topic: str, data: bytes) -> None:
         return await self.pubsub.publish(topic=topic, data=data)
 
-    async def pubsub_subscribe(
-        self, topic: str
-    ) -> Tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    async def pubsub_subscribe(self, topic: str) -> Tuple[anyio.abc.SocketStream]:
         return await self.pubsub.subscribe(topic=topic)

--- a/p2pclient/pubsub.py
+++ b/p2pclient/pubsub.py
@@ -57,7 +57,7 @@ class PubSubClient:
         await stream.close()
         raise_if_failed(resp)
 
-    async def subscribe(self, topic: str) -> Tuple[anyio.abc.SocketStream]:
+    async def subscribe(self, topic: str) -> anyio.abc.SocketStream:
         """PUBSUB SUBSCRIBE
         """
         pubsub_req = p2pd_pb.PSRequest(type=p2pd_pb.PSRequest.SUBSCRIBE, topic=topic)

--- a/p2pclient/utils.py
+++ b/p2pclient/utils.py
@@ -1,3 +1,6 @@
+from contextlib import closing
+import socket
+
 import anyio
 from google.protobuf.message import Message as PBMessage
 
@@ -22,3 +25,10 @@ async def read_pbmsg_safe(stream: anyio.abc.SocketStream, pbmsg: PBMessage) -> N
     len_msg_bytes = await read_unsigned_varint(stream)
     msg_bytes = await stream.receive_exactly(len_msg_bytes)
     pbmsg.ParseFromString(msg_bytes)
+
+
+def get_unused_tcp_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("localhost", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]

--- a/p2pclient/utils.py
+++ b/p2pclient/utils.py
@@ -11,14 +11,14 @@ def raise_if_failed(response: p2pd_pb.Response) -> None:
         raise ControlFailure(f"connect failed. msg={response.error.msg}")
 
 
-async def write_pbmsg(stream: anyio.abc.Stream, pbmsg: PBMessage) -> None:
+async def write_pbmsg(stream: anyio.abc.SocketStream, pbmsg: PBMessage) -> None:
     size = pbmsg.ByteSize()
     await write_unsigned_varint(stream, size)
     msg_bytes: bytes = pbmsg.SerializeToString()
     await stream.send_all(msg_bytes)
 
 
-async def read_pbmsg_safe(stream: anyio.abc.Stream, pbmsg: PBMessage) -> None:
+async def read_pbmsg_safe(stream: anyio.abc.SocketStream, pbmsg: PBMessage) -> None:
     len_msg_bytes = await read_unsigned_varint(stream)
     msg_bytes = await stream.receive_exactly(len_msg_bytes)
     pbmsg.ParseFromString(msg_bytes)

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,7 @@ with open("README.md", "r") as fh:
 
 
 extras_require = {
-    "test": [
-        "pytest>=4.6.3,<5.0.0",
-        "pytest-asyncio>=0.10.0,<1.0.0",
-        "pytest-cov>=2.7.1,<3.0.0",
-    ],
+    "test": ["pytest>=4.6.3,<5.0.0", "pytest-cov>=2.7.1,<3.0.0"],
     "lint": [
         "mypy>=0.701,<1.0",
         "mypy-protobuf>=1.15",
@@ -44,6 +40,9 @@ setuptools.setup(
         "protobuf>=3.9.0",
         "pymultihash>=0.8.2",
         "libp2p>=0.1.1",
+        "anyio>=1.2.2,<2.0.0",
+        "async-generator>=1.10,<2.0",
+        "async-exit-stack>=1.0.1,<2.0.0",
     ],
     extras_require=extras_require,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ with open("README.md", "r") as fh:
 extras_require = {
     "test": ["pytest>=4.6.3,<5.0.0", "pytest-cov>=2.7.1,<3.0.0"],
     "lint": [
-        "mypy>=0.701,<1.0",
-        "mypy-protobuf>=1.15",
+        "mypy>=0.761,<1.0",
+        "mypy-protobuf>=1.16",
         "black>=19.3b0",
         "isort>=4.3.21",
         "flake8>=3.7.7,<4.0.0",

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,5 +1,6 @@
 import io
 
+import anyio
 import pytest
 
 from p2pclient.serialization import read_unsigned_varint, write_unsigned_varint
@@ -23,35 +24,41 @@ pairs_int_varint_overflow = (
 
 
 class MockReaderWriter(io.BytesIO):
-    async def readexactly(self, n):
+    async def receive_exactly(self, n):
+        await anyio.sleep(0)
         return self.read(n)
+
+    async def send_all(self, b):
+        await anyio.sleep(0)
+        return self.write(b)
 
 
 @pytest.mark.parametrize("integer, var_integer", pairs_int_varint_valid)
-def test_write_unsigned_varint(integer, var_integer):
+@pytest.mark.anyio
+async def test_write_unsigned_varint(integer, var_integer):
     s = MockReaderWriter()
-    write_unsigned_varint(s, integer)
+    await write_unsigned_varint(s, integer)
     assert s.getvalue() == var_integer
 
 
 @pytest.mark.parametrize("integer", tuple(i[0] for i in pairs_int_varint_overflow))
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_write_unsigned_varint_overflow(integer):
     s = MockReaderWriter()
     with pytest.raises(ValueError):
-        write_unsigned_varint(s, integer)
+        await write_unsigned_varint(s, integer)
 
 
 @pytest.mark.parametrize("integer", (-1, -2 ** 32, -2 ** 64, -2 ** 128))
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_write_unsigned_varint_negative(integer):
     s = MockReaderWriter()
     with pytest.raises(ValueError):
-        write_unsigned_varint(s, integer)
+        await write_unsigned_varint(s, integer)
 
 
 @pytest.mark.parametrize("integer, var_integer", pairs_int_varint_valid)
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_read_unsigned_varint(integer, var_integer):
     s = MockReaderWriter(var_integer)
     result = await read_unsigned_varint(s)
@@ -59,7 +66,7 @@ async def test_read_unsigned_varint(integer, var_integer):
 
 
 @pytest.mark.parametrize("var_integer", tuple(i[1] for i in pairs_int_varint_overflow))
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_read_unsigned_varint_overflow(var_integer):
     s = MockReaderWriter(var_integer)
     with pytest.raises(ValueError):
@@ -67,7 +74,7 @@ async def test_read_unsigned_varint_overflow(var_integer):
 
 
 @pytest.mark.parametrize("max_bits", (2, 31, 32, 63, 64, 127, 128))
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_read_write_unsigned_varint_max_bits_edge(max_bits):
     """
     Test the edge with different `max_bits`
@@ -75,7 +82,7 @@ async def test_read_write_unsigned_varint_max_bits_edge(max_bits):
     for i in range(-3, 0):
         integer = i + (2 ** max_bits)
         s = MockReaderWriter()
-        write_unsigned_varint(s, integer, max_bits=max_bits)
+        await write_unsigned_varint(s, integer, max_bits=max_bits)
         s.seek(0, 0)
         result = await read_unsigned_varint(s, max_bits=max_bits)
         assert integer == result

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -49,7 +49,7 @@ async def test_write_unsigned_varint_overflow(integer):
         await write_unsigned_varint(s, integer)
 
 
-@pytest.mark.parametrize("integer", (-1, -2 ** 32, -2 ** 64, -2 ** 128))
+@pytest.mark.parametrize("integer", (-1, -(2 ** 32), -(2 ** 64), -(2 ** 128)))
 @pytest.mark.anyio
 async def test_write_unsigned_varint_negative(integer):
     s = MockReaderWriter()


### PR DESCRIPTION
To make this library useful in more IO frameworks, change to `anyio`.