### PR TITLE
fix: allow multiaddr 0.2.0 in dependency range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
         "async-exit-stack>=1.0.1,<2.0.0",
         "async-generator>=1.10,<2.0",
         "base58>=1.0.3",
-        "multiaddr>=0.0.8,<0.1.0",
+        "multiaddr>=0.0.8,<=0.2.0",
         "protobuf>=3.9.0",
         "pycryptodome>=3.0.0,<4.0.0",
         "py-multihash>=3.0.0",


### PR DESCRIPTION
## Summary
- update `multiaddr` dependency in `setup.py` to allow `0.2.0`
- unblock installs for projects that require `py-libp2p` and need `multiaddr==0.2.0`

## Test plan
- [ ] `source .venv/bin/activate`
- [ ] `pip install -e \".[test]\"`
- [ ] `python -c \"import multiaddr; print(multiaddr.__version__)\"`

Closes #61

Made with [Cursor](https://cursor.com)