### PR TITLE
ci: update deprecated GitHub Actions in unit tests workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,16 +21,16 @@ jobs:
         python-version: ["3.7", "3.8", "3.9"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install Go for p2pd
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: '1.12'
     - name: Install nodejs for jsp2pd
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: '16'
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cache/go-build
@@ -43,7 +43,7 @@ jobs:
     - name: Install jsp2pd
       run: npm install --global libp2p-daemon@0.10.2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python dependencies

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,8 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Tests disabled on Python 3.10 because of an issue with pytest
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- update deprecated actions in `.github/workflows/unit-tests.yml`
- replace `actions/cache@v2` (now hard-failing) with `actions/cache@v4`
- align related actions to maintained versions (`checkout`, `setup-go`, `setup-node`, `setup-python`)
- run matrix on supported versions `3.10`, `3.11`, `3.12`

## Why
PR checks were failing before tests ran due to deprecated action versions in the workflow setup stage.

## Test plan
- [ ] Verify workflow starts successfully on PR
- [ ] Verify matrix jobs (`3.10`, `3.11`, `3.12`) progress past setup

Closes #64